### PR TITLE
Add macro action enumeration and availability helper

### DIFF
--- a/src/macros/actions.py
+++ b/src/macros/actions.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""Macro-level actions and utilities.
+
+This module defines high-level macro actions available in the game and
+provides a utility to determine which of those actions are currently
+available given a simplified game state.
+"""
+
+from enum import Enum, auto
+from typing import Dict, List, Set
+
+
+class MacroAction(Enum):
+    """Enumeration of simplified macro actions."""
+
+    TRAIN_VILLAGER = auto()
+    AGE_UP_FEUDAL = auto()
+    BUILD_ARCHERY_RANGE = auto()
+
+
+def available_actions(state: Dict) -> List[MacroAction]:
+    """Return a list of available macro actions for a given state.
+
+    The ``state`` dictionary is expected to contain at least the keys
+    ``food`` (int), ``wood`` (int), ``age`` (str) and ``buildings``
+    (iterable of str).
+    """
+
+    food: int = state.get("food", 0)
+    wood: int = state.get("wood", 0)
+    age: str = state.get("age", "")
+    buildings: Set[str] = set(state.get("buildings", []))
+
+    actions: List[MacroAction] = []
+
+    if food >= 50 and "Town Center" in buildings:
+        actions.append(MacroAction.TRAIN_VILLAGER)
+
+    if age == "Dark Age" and food >= 500:
+        actions.append(MacroAction.AGE_UP_FEUDAL)
+
+    if age == "Feudal Age" and wood >= 175:
+        actions.append(MacroAction.BUILD_ARCHERY_RANGE)
+
+    return actions

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,36 @@
+import os
+import sys
+
+import pytest
+
+# Ensure src is on path
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from macros.actions import MacroAction, available_actions
+
+
+def test_no_actions_available():
+    state = {"food": 0, "wood": 0, "age": "Dark Age", "buildings": {"Town Center"}}
+    assert available_actions(state) == []
+
+
+def test_train_villager_available():
+    state = {"food": 50, "wood": 0, "age": "Dark Age", "buildings": {"Town Center"}}
+    assert available_actions(state) == [MacroAction.TRAIN_VILLAGER]
+
+
+def test_age_up_and_train_villager_available():
+    state = {"food": 500, "wood": 0, "age": "Dark Age", "buildings": {"Town Center"}}
+    actions = available_actions(state)
+    assert set(actions) == {MacroAction.TRAIN_VILLAGER, MacroAction.AGE_UP_FEUDAL}
+
+
+def test_build_archery_range_available():
+    state = {
+        "food": 100,
+        "wood": 200,
+        "age": "Feudal Age",
+        "buildings": {"Town Center"},
+    }
+    actions = available_actions(state)
+    assert set(actions) == {MacroAction.TRAIN_VILLAGER, MacroAction.BUILD_ARCHERY_RANGE}


### PR DESCRIPTION
## Summary
- define `MacroAction` enum for core macro actions
- implement `available_actions` utility to list valid actions for a given state
- add tests covering possible action scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba753df2ec8325a3f1c61c2710312e