### PR TITLE
Add parsing tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🏰 Age of Empires Human-Guided RL
 
+[![Tests](https://github.com/OWNER/AoE2DE/actions/workflows/tests.yml/badge.svg)](https://github.com/OWNER/AoE2DE/actions/workflows/tests.yml)
+
 Este repositório explora **Aprendizado por Reforço (Reinforcement Learning)** combinado com **Aprendizado por Demonstração (Imitation Learning / Inverse Reinforcement Learning)** aplicado ao jogo **Age of Empires II: Definitive Edition**.
 
 A ideia central é **observar a performance humana** em *replays* para:

--- a/src/parsing/__init__.py
+++ b/src/parsing/__init__.py
@@ -1,1 +1,46 @@
-"""Parsing package."""
+"""Simple utilities for parsing macro action strings.
+
+This module currently provides a minimal parser that converts human readable
+strings into the :class:`~macros.actions.MacroAction` enum used throughout the
+project.  The goal is to keep the mapping logic in one place so both the
+environment and tests rely on the same behaviour.
+"""
+
+from __future__ import annotations
+
+from macros.actions import MacroAction
+
+
+def parse_macro_action(text: str) -> MacroAction:
+    """Parse ``text`` into a :class:`~macros.actions.MacroAction`.
+
+    Parameters
+    ----------
+    text:
+        Human readable name of the action, e.g. ``"train villager"``.
+
+    Returns
+    -------
+    macros.actions.MacroAction
+        The corresponding enum value.
+
+    Raises
+    ------
+    ValueError
+        If ``text`` does not correspond to a known action.
+    """
+
+    normalized = text.strip().lower()
+    mapping = {
+        "train villager": MacroAction.TRAIN_VILLAGER,
+        "age up": MacroAction.AGE_UP_FEUDAL,
+        "build archery range": MacroAction.BUILD_ARCHERY_RANGE,
+    }
+    try:
+        return mapping[normalized]
+    except KeyError as exc:  # pragma: no cover - error path
+        raise ValueError(f"Unknown action: {text}") from exc
+
+
+__all__ = ["parse_macro_action"]
+

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+import pytest
+
+# Ensure src is on path
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from parsing import parse_macro_action
+from macros.actions import MacroAction
+
+
+def test_parse_valid_actions():
+    assert parse_macro_action("train villager") == MacroAction.TRAIN_VILLAGER
+    assert parse_macro_action("age up") == MacroAction.AGE_UP_FEUDAL
+    assert parse_macro_action("build archery range") == MacroAction.BUILD_ARCHERY_RANGE
+
+
+def test_parse_invalid_action():
+    with pytest.raises(ValueError):
+        parse_macro_action("fly to the moon")


### PR DESCRIPTION
## Summary
- add macro action string parser and corresponding tests
- configure GitHub Actions to run pytest
- include CI status badge in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb3c35a9408325ad42b6a4f7c040ab