### PR TITLE
Refactor macros actions to use GameState dataclass

### DIFF
--- a/src/macros/actions.py
+++ b/src/macros/actions.py
@@ -8,7 +8,9 @@ available given a simplified game state.
 """
 
 from enum import Enum, auto
-from typing import Dict, List, Set
+from typing import List, Set
+
+from .state import GameState
 
 
 class MacroAction(Enum):
@@ -19,18 +21,13 @@ class MacroAction(Enum):
     BUILD_ARCHERY_RANGE = auto()
 
 
-def available_actions(state: Dict) -> List[MacroAction]:
-    """Return a list of available macro actions for a given state.
+def available_actions(state: GameState) -> List[MacroAction]:
+    """Return a list of available macro actions for a given state."""
 
-    The ``state`` dictionary is expected to contain at least the keys
-    ``food`` (int), ``wood`` (int), ``age`` (str) and ``buildings``
-    (iterable of str).
-    """
-
-    food: int = state.get("food", 0)
-    wood: int = state.get("wood", 0)
-    age: str = state.get("age", "")
-    buildings: Set[str] = set(state.get("buildings", []))
+    food: int = state.food
+    wood: int = state.wood
+    age: str = state.age
+    buildings: Set[str] = set(state.buildings)
 
     actions: List[MacroAction] = []
 

--- a/src/macros/state.py
+++ b/src/macros/state.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Set
+
+
+@dataclass
+class GameState:
+    """Simplified representation of the game state."""
+
+    food: int = 0
+    wood: int = 0
+    age: str = ""
+    buildings: Set[str] = field(default_factory=set)

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -7,30 +7,26 @@ import pytest
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from macros.actions import MacroAction, available_actions
+from macros.state import GameState
 
 
 def test_no_actions_available():
-    state = {"food": 0, "wood": 0, "age": "Dark Age", "buildings": {"Town Center"}}
+    state = GameState(food=0, wood=0, age="Dark Age", buildings={"Town Center"})
     assert available_actions(state) == []
 
 
 def test_train_villager_available():
-    state = {"food": 50, "wood": 0, "age": "Dark Age", "buildings": {"Town Center"}}
+    state = GameState(food=50, wood=0, age="Dark Age", buildings={"Town Center"})
     assert available_actions(state) == [MacroAction.TRAIN_VILLAGER]
 
 
 def test_age_up_and_train_villager_available():
-    state = {"food": 500, "wood": 0, "age": "Dark Age", "buildings": {"Town Center"}}
+    state = GameState(food=500, wood=0, age="Dark Age", buildings={"Town Center"})
     actions = available_actions(state)
     assert set(actions) == {MacroAction.TRAIN_VILLAGER, MacroAction.AGE_UP_FEUDAL}
 
 
 def test_build_archery_range_available():
-    state = {
-        "food": 100,
-        "wood": 200,
-        "age": "Feudal Age",
-        "buildings": {"Town Center"},
-    }
+    state = GameState(food=100, wood=200, age="Feudal Age", buildings={"Town Center"})
     actions = available_actions(state)
     assert set(actions) == {MacroAction.TRAIN_VILLAGER, MacroAction.BUILD_ARCHERY_RANGE}


### PR DESCRIPTION
## Summary
- add GameState dataclass for simplified state representation
- update macro actions to consume GameState instead of dict
- adapt tests to construct GameState instances

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb3d3d087883258756473671933497