### PR TITLE
Validate BC transition lengths and add error handling test

### DIFF
--- a/src/policies/bc_train.py
+++ b/src/policies/bc_train.py
@@ -44,6 +44,10 @@ def load_transitions(data_dir: Path) -> types.Transitions:
         data = np.load(file)
         obs = data["obs"]
         acts = data["acts"]
+        if len(obs) != len(acts):
+            raise ValueError(
+                f"In {file}, obs and acts have mismatched lengths: {len(obs)} != {len(acts)}"
+            )
         next_obs = data.get("next_obs")
         if next_obs is None:
             # Placeholder next observations; not required for BC but part of API

--- a/tests/test_bc_train.py
+++ b/tests/test_bc_train.py
@@ -1,0 +1,45 @@
+import sys
+import types
+import os
+
+import numpy as np
+import pytest
+
+
+def test_load_transitions_mismatched_lengths(tmp_path, monkeypatch):
+    # Create dummy imitation package so bc_train can be imported without the real dependency
+    imitation = types.ModuleType("imitation")
+    algorithms = types.ModuleType("imitation.algorithms")
+    bc = types.ModuleType("imitation.algorithms.bc")
+    algorithms.bc = bc
+    data = types.ModuleType("imitation.data")
+    types_mod = types.ModuleType("imitation.data.types")
+
+    class Transitions:  # pragma: no cover - simple placeholder
+        pass
+
+    types_mod.Transitions = Transitions
+    data.types = types_mod
+    imitation.algorithms = algorithms
+    imitation.data = data
+
+    monkeypatch.setitem(sys.modules, "imitation", imitation)
+    monkeypatch.setitem(sys.modules, "imitation.algorithms", algorithms)
+    monkeypatch.setitem(sys.modules, "imitation.algorithms.bc", bc)
+    monkeypatch.setitem(sys.modules, "imitation.data", data)
+    monkeypatch.setitem(sys.modules, "imitation.data.types", types_mod)
+    gymnasium = types.ModuleType("gymnasium")
+    spaces = types.ModuleType("gymnasium.spaces")
+    gymnasium.spaces = spaces
+    monkeypatch.setitem(sys.modules, "gymnasium", gymnasium)
+    monkeypatch.setitem(sys.modules, "gymnasium.spaces", spaces)
+
+    sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+    from policies.bc_train import load_transitions
+
+    # Create a trajectory file with mismatched obs and acts lengths
+    path = tmp_path / "traj.npz"
+    np.savez(path, obs=np.zeros((5, 3)), acts=np.zeros(4))
+
+    with pytest.raises(ValueError, match="mismatched lengths"):
+        load_transitions(tmp_path)


### PR DESCRIPTION
## Summary
- verify observation and action arrays in trajectory files match in length when loading transitions
- raise a clear `ValueError` if a mismatch is detected
- add unit test covering mismatched trajectory file lengths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb3dde2e1c83258940703019e1ff21