### PR TITLE
Add CLI scripts for preprocessing, training, and running agent

### DIFF
--- a/scripts/preprocess_replays.py
+++ b/scripts/preprocess_replays.py
@@ -1,0 +1,42 @@
+"""Utility to preprocess AoE2DE replays into training episodes."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def preprocess_replays(input_dir: str | Path, output_dir: str | Path) -> None:
+    """Convert raw replay files into structured episodes.
+
+    Parameters
+    ----------
+    input_dir:
+        Directory containing raw replay files.
+    output_dir:
+        Directory where processed episodes will be written.
+    """
+    input_path = Path(input_dir)
+    output_path = Path(output_dir)
+    # Placeholder implementation – real preprocessing would parse replay files.
+    output_path.mkdir(parents=True, exist_ok=True)
+    print(f"Pretending to preprocess replays from {input_path} to {output_path}")
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Preprocess AoE2DE replay files.")
+    parser.add_argument("--input", required=True, help="Directory with replay files")
+    parser.add_argument(
+        "--output", required=True, help="Directory to store processed episodes"
+    )
+    return parser
+
+
+def main() -> None:
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+    preprocess_replays(args.input, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -1,0 +1,33 @@
+"""Run a trained agent on a specific AoE2DE campaign mission."""
+
+from __future__ import annotations
+
+import argparse
+
+
+def run_agent(mission_name: str) -> None:
+    """Execute the trained agent for a given campaign mission.
+
+    Parameters
+    ----------
+    mission_name:
+        Human-readable name of the campaign mission to play.
+    """
+    # Placeholder implementation – this would launch the game and control the agent.
+    print(f"Pretending to run agent on mission '{mission_name}'")
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the trained AoE2DE agent.")
+    parser.add_argument("--mission", required=True, help="Name of the campaign mission")
+    return parser
+
+
+def main() -> None:
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+    run_agent(args.mission)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_agent.py
+++ b/scripts/train_agent.py
@@ -1,0 +1,35 @@
+"""Train a campaign-playing agent from preprocessed data."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def train_agent(config_path: str | Path) -> None:
+    """Train the imitation agent using the provided configuration file.
+
+    Parameters
+    ----------
+    config_path:
+        Path to the YAML/JSON configuration file.
+    """
+    cfg = Path(config_path)
+    # Placeholder implementation – real training logic would be invoked here.
+    print(f"Pretending to train agent with config at {cfg}")
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Train the AoE2DE agent.")
+    parser.add_argument("--config", required=True, help="Path to config file")
+    return parser
+
+
+def main() -> None:
+    parser = _build_arg_parser()
+    args = parser.parse_args()
+    train_agent(args.config)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add placeholder script to preprocess replays with input/output CLI
- add training script with config-based CLI interface
- add run script for launching trained agent via mission name

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb46d80458832595f79617fb57af9a