### PR TITLE
feat: parse HUD state and objectives

### DIFF
--- a/src/env/__init__.py
+++ b/src/env/__init__.py
@@ -12,15 +12,19 @@ with the game.
 from __future__ import annotations
 
 import logging
-from typing import Dict, Iterable, List
+import re
+from typing import Dict, Iterable, List, Mapping, Optional
 
 # Mapping from macro actions (indices predicted by the model) to concrete
 # sequences of hotkey commands to be sent to the game.  The mapping here is a
 # tiny placeholder and should be extended to cover the full action space of the
 # agent.
 ACTION_MAP: Dict[int, Iterable[str]] = {
-    0: ["space"],  # e.g. jump to idle villager
-    1: ["a"],      # generic example action
+    0: ["space"],          # e.g. jump to idle villager
+    1: ["a"],              # generic example action
+    2: ["b", "v"],        # train a villager at the town centre
+    3: ["b", "b"],        # build a house
+    4: ["b", "a"],        # build a barracks
 }
 
 
@@ -40,9 +44,9 @@ class AoE2DEEnvironment:
         """Capture the current game state as a numeric vector.
 
         The default implementation grabs a screenshot of the active monitor and
-        runs OCR over it.  The resulting text is converted into a very small set
-        of numerical features.  Real agents would parse individual numbers from
-        the HUD instead of using this crude representation.
+        runs OCR over it.  The resulting text is then parsed for the four resource
+        numbers (food, wood, gold, stone) and the current and maximum population.
+        If parsing fails, missing fields default to ``0``.
         """
 
         try:
@@ -56,10 +60,26 @@ class AoE2DEEnvironment:
         screenshot = pyautogui.screenshot()
         text = pytesseract.image_to_string(screenshot)
 
-        # For demonstration purposes the state is simply the length of the OCR'd
-        # text.  A proper implementation would parse resources, unit counts, etc.
-        state = [float(len(text))]
-        self.log.debug("Captured state %s", state)
+        numbers = [int(n) for n in re.findall(r"\d+", text)]
+        food = numbers[0] if len(numbers) > 0 else 0
+        wood = numbers[1] if len(numbers) > 1 else 0
+        gold = numbers[2] if len(numbers) > 2 else 0
+        stone = numbers[3] if len(numbers) > 3 else 0
+
+        pop_cur, pop_cap = 0, 0
+        pop_match = re.search(r"(\d+)\s*/\s*(\d+)", text)
+        if pop_match:
+            pop_cur, pop_cap = map(int, pop_match.groups())
+
+        state = [
+            float(food),
+            float(wood),
+            float(gold),
+            float(stone),
+            float(pop_cur),
+            float(pop_cap),
+        ]
+        self.log.debug("Captured state %s from text %r", state, text)
         return state
 
     def send_action(self, action: int) -> None:
@@ -78,10 +98,43 @@ class AoE2DEEnvironment:
 
     # The following two helpers are intentionally very small and serve mainly as
     # extension points for real‑world implementations.
-    def objectives_completed(self) -> bool:
-        """Return ``True`` when mission objectives are satisfied."""
+    def objectives_completed(
+        self,
+        objectives: Optional[Mapping[str, float]] = None,
+        state: Optional[List[float]] = None,
+    ) -> bool:
+        """Check whether the supplied mission ``objectives`` are satisfied.
 
-        return False
+        Parameters
+        ----------
+        objectives:
+            Mapping of resource/population names to minimum required values.
+        state:
+            Optional pre‑computed state vector as returned by :meth:`read_state`.
+            If not provided, :meth:`read_state` is invoked.
+        """
+
+        if objectives is None:
+            objectives = {}
+        if state is None:
+            state = self.read_state()
+
+        mapping = {
+            "food": 0,
+            "wood": 1,
+            "gold": 2,
+            "stone": 3,
+            "population": 4,
+            "pop_cap": 5,
+        }
+
+        for key, required in objectives.items():
+            idx = mapping.get(key)
+            if idx is None:
+                continue
+            if state[idx] < required:
+                return False
+        return True
 
     def close(self) -> None:  # pragma: no cover - simple resource release
         """Clean up any held resources (none for the placeholder)."""

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from src.env import ACTION_MAP, AoE2DEEnvironment
+
+
+def test_send_action_triggers_hotkeys(monkeypatch: pytest.MonkeyPatch) -> None:
+    pressed: list[str] = []
+
+    def fake_press(key: str) -> None:
+        pressed.append(key)
+
+    fake_pyautogui = SimpleNamespace(press=fake_press)
+    monkeypatch.setitem(sys.modules, "pyautogui", fake_pyautogui)
+
+    env = AoE2DEEnvironment()
+    env.send_action(2)
+    assert pressed == list(ACTION_MAP[2])
+
+
+def test_read_state_parses_resources(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_pyautogui = SimpleNamespace(screenshot=lambda: object())
+    fake_text = "100 200 300 400\n10/50"
+    fake_pytesseract = SimpleNamespace(image_to_string=lambda img: fake_text)
+
+    monkeypatch.setitem(sys.modules, "pyautogui", fake_pyautogui)
+    monkeypatch.setitem(sys.modules, "pytesseract", fake_pytesseract)
+
+    env = AoE2DEEnvironment()
+    state = env.read_state()
+    assert state == [100.0, 200.0, 300.0, 400.0, 10.0, 50.0]
+
+
+def test_objectives_completed(monkeypatch: pytest.MonkeyPatch) -> None:
+    env = AoE2DEEnvironment()
+    state = [100.0, 50.0, 25.0, 10.0, 30.0, 40.0]
+    assert env.objectives_completed({"food": 100, "population": 30}, state)
+    assert not env.objectives_completed({"wood": 100}, state)
+
+    monkeypatch.setattr(env, "read_state", lambda: state)
+    assert env.objectives_completed({"food": 100, "population": 30})


### PR DESCRIPTION
## Summary
- add richer ACTION_MAP entries for unit training and building
- parse OCR HUD text into resources and population
- implement mission objective checker and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb5b4299f483259af40ebcfff35a82