### PR TITLE
Refactor SimpleTransformer into reusable module with tests

### DIFF
--- a/scripts/run_agent.py
+++ b/scripts/run_agent.py
@@ -11,7 +11,7 @@ from typing import List
 
 import torch
 
-from train_agent import SimpleTransformer
+from src.agent.model import SimpleTransformer
 from src.env import AoE2DEEnvironment
 
 

--- a/scripts/train_agent.py
+++ b/scripts/train_agent.py
@@ -15,10 +15,12 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Tuple
 
 import torch
-from torch import nn, optim
+from torch import optim
 from torch.nn import functional as F
 from torch.utils.data import DataLoader, Dataset
 from torch.utils.tensorboard import SummaryWriter
+
+from src.agent.model import SimpleTransformer
 
 
 def load_config(path: Path) -> Dict[str, Any]:
@@ -60,24 +62,6 @@ class EpisodeDataset(Dataset[Tuple[torch.Tensor, torch.Tensor]]):
 
     def __getitem__(self, idx: int) -> Tuple[torch.Tensor, torch.Tensor]:
         return self.samples[idx]
-
-
-class SimpleTransformer(nn.Module):
-    """Minimal Transformer-based policy network."""
-
-    def __init__(self, state_dim: int, num_actions: int, d_model: int = 64,
-                 nhead: int = 4, num_layers: int = 2) -> None:
-        super().__init__()
-        self.input_proj = nn.Linear(state_dim, d_model)
-        layer = nn.TransformerEncoderLayer(d_model=d_model, nhead=nhead,
-                                           batch_first=True)
-        self.encoder = nn.TransformerEncoder(layer, num_layers=num_layers)
-        self.policy = nn.Linear(d_model, num_actions)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:  # pragma: no cover - simple passthrough
-        x = self.input_proj(x)
-        x = self.encoder(x)
-        return self.policy(x[:, -1])
 
 
 def train_agent(config_path: str | Path, output_dir: str | Path, epochs: int,

--- a/src/agent/__init__.py
+++ b/src/agent/__init__.py
@@ -1,0 +1,5 @@
+"""Agent package providing model and related utilities."""
+
+from .model import SimpleTransformer
+
+__all__ = ["SimpleTransformer"]

--- a/src/agent/model.py
+++ b/src/agent/model.py
@@ -1,0 +1,66 @@
+"""Model definitions for the AoE2DE agent.
+
+This module currently exposes :class:`SimpleTransformer`, a minimal
+Transformer-based policy network used by the training and inference
+scripts.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+class SimpleTransformer(nn.Module):
+    """Minimal Transformer-based policy network for AoE2DE.
+
+    Parameters
+    ----------
+    state_dim:
+        Dimensionality of the input state representation.
+    num_actions:
+        Number of discrete actions the agent can take.
+    d_model:
+        Size of the model's hidden representations. Defaults to ``64``.
+    nhead:
+        Number of attention heads in each Transformer encoder layer.
+        Defaults to ``4``.
+    num_layers:
+        Number of Transformer encoder layers. Defaults to ``2``.
+    """
+
+    def __init__(
+        self,
+        state_dim: int,
+        num_actions: int,
+        d_model: int = 64,
+        nhead: int = 4,
+        num_layers: int = 2,
+    ) -> None:
+        super().__init__()
+        self.input_proj = nn.Linear(state_dim, d_model)
+        layer = nn.TransformerEncoderLayer(
+            d_model=d_model, nhead=nhead, batch_first=True
+        )
+        self.encoder = nn.TransformerEncoder(layer, num_layers=num_layers)
+        self.policy = nn.Linear(d_model, num_actions)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Compute action logits for a batch of states.
+
+        Parameters
+        ----------
+        x:
+            Tensor of shape ``(batch, seq_len, state_dim)`` representing a
+            batch of state sequences.
+
+        Returns
+        -------
+        torch.Tensor
+            Logits over actions of shape ``(batch, num_actions)`` corresponding
+            to the final state in each sequence.
+        """
+
+        x = self.input_proj(x)
+        x = self.encoder(x)
+        return self.policy(x[:, -1])

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import torch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "scripts"))
+
+from run_agent import load_model
+from src.agent.model import SimpleTransformer
+
+
+def test_forward_pass() -> None:
+    model = SimpleTransformer(state_dim=4, num_actions=3, d_model=8, nhead=2, num_layers=1)
+    x = torch.randn(2, 5, 4)
+    logits = model(x)
+    assert logits.shape == (2, 3)
+
+
+def test_weight_loading(tmp_path: Path) -> None:
+    model = SimpleTransformer(state_dim=4, num_actions=3, d_model=8, nhead=2, num_layers=1)
+    ckpt = {"model": model.state_dict()}
+    weights = tmp_path / "weights.pt"
+    torch.save(ckpt, weights)
+
+    loaded = load_model(weights, torch.device("cpu"))
+    for p_orig, p_loaded in zip(model.parameters(), loaded.parameters()):
+        assert torch.equal(p_orig, p_loaded)


### PR DESCRIPTION
## Summary
- Extract `SimpleTransformer` into `src/agent/model.py` with comprehensive documentation and expose via package
- Update training and runtime scripts to import the model from the new module
- Add unit tests ensuring forward pass shape and checkpoint loading

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb5bd1f180832588f44daa933599b1