### PR TITLE
Add CLI dispatcher for project scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,15 @@ pip install -r requirements-dev.txt
 1. Colete replays e salve em `data/`.  
 2. Pré-processe dados:
 ```bash
-python scripts/preprocess_replays.py --input data/replays --output data/episodes
+python main.py preprocess --input data/replays --output data/episodes
 ```
 3. Treine o agente:
 ```bash
-python scripts/train_agent.py --config configs/bc.yaml
+python main.py train --config configs/bc.yaml --output-dir models/
 ```
 4. Execute em campanha:
 ```bash
-python scripts/run_agent.py --mission "William Wallace 4"
+python main.py run --mission "William Wallace 4"
 ```
 
 ---

--- a/main.py
+++ b/main.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def main() -> None:
+    """Entry point that dispatches to project scripts via subcommands."""
+    parser = argparse.ArgumentParser(description="AoE2DE command line interface")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("train", help="Treina o agente")
+    subparsers.add_parser("run", help="Executa o agente em campanha")
+    subparsers.add_parser("preprocess", help="Processa replays")
+
+    args, remaining = parser.parse_known_args()
+
+    if args.command == "train":
+        from scripts import train_agent
+
+        sys.argv = ["train_agent.py", *remaining]
+        train_agent.main()
+    elif args.command == "run":
+        from scripts import run_agent
+
+        sys.argv = ["run_agent.py", *remaining]
+        run_agent.main()
+    elif args.command == "preprocess":
+        from scripts import preprocess_replays
+
+        sys.argv = ["preprocess_replays.py", *remaining]
+        preprocess_replays.main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add argparse-based CLI with train, run, and preprocess subcommands
- document new `python main.py <subcommand>` usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68bb602a15c88325803b79e27535fd2a