### PR TITLE
Improve replay parser robustness

### DIFF
--- a/tests/test_replay_parser.py
+++ b/tests/test_replay_parser.py
@@ -9,7 +9,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pytest
 
-from src.utils.replay_parser import ReplayParser
+from src.utils.replay_parser import ReplayParser, UnsupportedReplayFormat
 
 
 def _write_mgz(file: Path, events: list[tuple[int, str, str]]) -> None:
@@ -40,11 +40,44 @@ def test_parse_valid_mgz(tmp_path: Path) -> None:
 
 def test_corrupted_file(tmp_path: Path) -> None:
     path = tmp_path / "bad.aoe2record"
-    # Write event count and a partial event (timestamp only)
+    # Write event count and a partial event with truncated player name
+    with path.open("wb") as f:
+        f.write(struct.pack("<I", 1))
+        f.write(struct.pack("<I", 1234))
+        f.write(bytes([3]))  # declared player name length
+        f.write(b"AB")  # only two bytes provided
+
+    parser = ReplayParser()
+    with pytest.raises(ValueError):
+        parser.parse(path)
+
+
+def test_unsupported_header(tmp_path: Path) -> None:
+    path = tmp_path / "unsupported.aoe2record"
+    # Write event count but not enough bytes for even a minimal event
     with path.open("wb") as f:
         f.write(struct.pack("<I", 1))
         f.write(struct.pack("<I", 1234))
 
     parser = ReplayParser()
-    with pytest.raises(ValueError):
+    with pytest.raises(UnsupportedReplayFormat):
         parser.parse(path)
+
+
+def test_non_utf8_bytes(tmp_path: Path) -> None:
+    path = tmp_path / "enc.mgz"
+    with gzip.open(path, "wb") as f:
+        f.write(struct.pack("<I", 1))
+        f.write(struct.pack("<I", 1000))
+        player_bytes = b"Alice\xff"
+        event_bytes = b"move\xff"
+        f.write(bytes([len(player_bytes)]))
+        f.write(player_bytes)
+        f.write(bytes([len(event_bytes)]))
+        f.write(event_bytes)
+
+    parser = ReplayParser()
+    result = parser.parse(path)
+    assert result == [
+        {"timestamp": 1000, "player": "Aliceÿ", "event": "moveÿ"}
+    ]


### PR DESCRIPTION
## Summary
- add `UnsupportedReplayFormat` exception and validate replay headers
- decode player/event names with robust fallback to handle non-UTF-8 bytes
- expand parser tests for unsupported files and non UTF-8 data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb63ce36388325a5b25e76f06cbc09