### PR TITLE
Integrate mgz replay parsing and metadata extraction

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pytesseract>=0.3.10,<0.4
 numpy>=1.20,<2.0
 pyyaml>=6.0,<7.0
 tensorboard>=2.13,<3.0
+mgz>=1.8.39

--- a/scripts/preprocess_replays.py
+++ b/scripts/preprocess_replays.py
@@ -26,11 +26,10 @@ def _iter_replay_files(directory: Path) -> Iterable[Path]:
 def _process_replay(replay_path: Path, output_dir: Path) -> None:
     parser = ReplayParser()
     try:
-        events = parser.parse(replay_path)
-        episode = {"events": events}
+        metadata = parser.parse(replay_path)
         out_file = output_dir / f"{replay_path.stem}.json"
         with out_file.open("w", encoding="utf-8") as f:
-            json.dump(episode, f, indent=2)
+            json.dump(metadata, f, indent=2)
         logger.info("Processed %s", replay_path.name)
     except Exception as exc:  # pragma: no cover - logging path
         logger.error("Failed to process %s: %s", replay_path, exc, exc_info=True)


### PR DESCRIPTION
## Summary
- replace toy replay parser with mgz-based implementation that reads the real `.aoe2record` header, extracts version, map and players, and verifies CRC32 checksums
- update preprocessing script to emit parsed metadata
- add mgz dependency and new tests for parsing and checksum validation

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found for torch<2.0,>=1.13)*
- `pytest tests/test_replay_parser.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb6955c6048325ac2a34f839ed300b