### PR TITLE
Detect gzip replay files via magic number

### DIFF
--- a/tests/test_replay_parser.py
+++ b/tests/test_replay_parser.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 import sys
 import zlib
+import gzip
 
 import mgz
 from construct import ConstructError
@@ -68,4 +69,14 @@ def test_unsupported_replay(monkeypatch, tmp_path: Path) -> None:
     parser = ReplayParser()
     with pytest.raises(UnsupportedReplayFormat):
         parser.parse(path)
+
+
+def test_open_detects_gzip_magic(tmp_path: Path) -> None:
+    path = tmp_path / "game.aoe2record"
+    with gzip.open(path, "wb") as fh:
+        fh.write(b"data")
+
+    parser = ReplayParser()
+    with parser._open(path) as fh:
+        assert fh.read() == b"data"
 


### PR DESCRIPTION
## Summary
- Determine gzip compression by inspecting magic bytes rather than file suffix
- Document gzip detection in replay parser
- Test gzip magic byte detection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb72a79b948325b8d00ef9640985d2