### PR TITLE
Handle null checksum strings in replay parser

### DIFF
--- a/src/utils/replay_parser.py
+++ b/src/utils/replay_parser.py
@@ -122,9 +122,13 @@ class ReplayParser:
                     skipped += 1
                     continue
                 crc = entry.get("crc")
-                data = entry.get("string", {}).get("value", b"")
                 if crc in (None, 0):
                     continue
+                string_entry = entry.get("string")
+                if isinstance(string_entry, dict):
+                    data = string_entry.get("value", b"") or b""
+                else:
+                    data = b""
                 if zlib.crc32(data) & 0xFFFFFFFF != crc:
                     raise ValueError("Checksum mismatch in string block")
 

--- a/tests/test_replay_parser.py
+++ b/tests/test_replay_parser.py
@@ -80,3 +80,14 @@ def test_open_detects_gzip_magic(tmp_path: Path) -> None:
     with parser._open(path) as fh:
         assert fh.read() == b"data"
 
+
+def test_checksum_entry_with_null_string(monkeypatch, tmp_path: Path) -> None:
+    path = tmp_path / "null.aoe2record"
+    path.write_bytes(b"fake")
+    header = _make_header()
+    header["de"]["rms_strings"]["strings"].append({"crc": None, "string": None})
+    monkeypatch.setattr(type(mgz.header), "parse_stream", lambda self, fh: header)
+
+    parser = ReplayParser()
+    parser.parse(path)
+


### PR DESCRIPTION
## Summary
- Skip checksum validation for entries with missing or zero CRC, avoiding string parsing
- Guard against non-dict string fields and support `None` string entries
- Test that `ReplayParser.parse` handles checksum entries with `string=None`

## Testing
- `pytest tests/test_replay_parser.py::test_checksum_entry_with_null_string -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb74fa697c83259261ef209e3d2687