### PR TITLE
Add action space utilities and mask computation

### DIFF
--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility functions for the AoE2DE project."""

--- a/src/utils/action_space.py
+++ b/src/utils/action_space.py
@@ -1,0 +1,29 @@
+"""Action space definitions for mapping action IDs to (verb, argument).
+
+This module defines a small, illustrative mapping between integer action
+identifiers and the corresponding verb/argument pair that describes the action.
+"""
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+# Mapping from action ID to (verb, argument)
+ACTION_ID_TO_COMPONENTS: Dict[int, Tuple[str, str]] = {
+    0: ("move", "north"),
+    1: ("move", "south"),
+    2: ("attack", "melee"),
+    3: ("build", "house"),
+}
+
+# Automatically create the inverse mapping
+COMPONENTS_TO_ACTION_ID: Dict[Tuple[str, str], int] = {
+    components: action_id for action_id, components in ACTION_ID_TO_COMPONENTS.items()
+}
+
+def get_action_components(action_id: int) -> Tuple[str, str]:
+    """Return the (verb, argument) pair for a given action ID."""
+    return ACTION_ID_TO_COMPONENTS[action_id]
+
+def get_action_id(verb: str, argument: str) -> int:
+    """Return the action ID for a given verb and argument."""
+    return COMPONENTS_TO_ACTION_ID[(verb, argument)]

--- a/src/utils/mask.py
+++ b/src/utils/mask.py
@@ -1,0 +1,17 @@
+"""Mask computation utilities."""
+from __future__ import annotations
+
+from typing import Iterable
+
+import torch
+from torch import Tensor
+
+
+def compute_valid_mask(state: Iterable[bool]) -> Tensor:
+    """Compute a boolean mask indicating which actions are valid.
+
+    The ``state`` argument is expected to be an iterable of truthy/falsy
+    values, where each element corresponds to the validity of an action.
+    The function returns a :class:`torch.Tensor` of dtype ``torch.bool``.
+    """
+    return torch.as_tensor(list(state), dtype=torch.bool)

--- a/tests/test_action_space.py
+++ b/tests/test_action_space.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.utils.action_space import (
+    ACTION_ID_TO_COMPONENTS,
+    COMPONENTS_TO_ACTION_ID,
+    get_action_components,
+    get_action_id,
+)
+
+
+def test_round_trip_action_mappings():
+    """Each action ID should map to components and back again."""
+    for action_id, components in ACTION_ID_TO_COMPONENTS.items():
+        assert get_action_components(action_id) == components
+        assert get_action_id(*components) == action_id
+
+    # Also verify that the inverse mapping matches
+    for components, action_id in COMPONENTS_TO_ACTION_ID.items():
+        assert ACTION_ID_TO_COMPONENTS[action_id] == components

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import torch
+
+from src.utils.mask import compute_valid_mask
+
+
+def test_compute_valid_mask():
+    state = [1, 0, True, False]
+    mask = compute_valid_mask(state)
+
+    expected = torch.tensor([True, False, True, False])
+    assert torch.equal(mask, expected)
+    assert mask.dtype == torch.bool


### PR DESCRIPTION
## Summary
- define mapping between action IDs and (verb, argument)
- add `compute_valid_mask` for converting state to boolean torch tensor
- include basic unit tests for the new utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bbb4c186ac8325927898b68587d3fc