### PR TITLE
Add policy network classes with mask handling

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,5 @@
+"""Model classes for policy networks."""
+
+from .policy import MLPPolicy, TransformerPolicy
+
+__all__ = ["MLPPolicy", "TransformerPolicy"]

--- a/src/models/policy.py
+++ b/src/models/policy.py
@@ -1,0 +1,69 @@
+"""Policy network implementations."""
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from torch import Tensor, nn
+
+
+class MLPPolicy(nn.Module):
+    """Simple multi-layer perceptron policy network.
+
+    Parameters
+    ----------
+    input_dim:
+        Size of the input state vector.
+    hidden_dim:
+        Number of units in the hidden layer.
+    output_dim:
+        Number of possible actions (size of the output logits).
+    """
+
+    def __init__(self, input_dim: int, hidden_dim: int, output_dim: int) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(input_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, output_dim),
+        )
+
+    def forward(self, state: Tensor, mask: Optional[Tensor] = None) -> Tensor:
+        """Compute masked action logits.
+
+        The ``mask`` should be a boolean tensor where ``False`` entries mark
+        invalid actions. These entries are set to ``-inf`` in the returned
+        logits, ensuring the mask is respected during both training and
+        inference.
+        """
+        logits = self.net(state)
+        if mask is not None:
+            logits = logits.masked_fill(~mask, float("-inf"))
+        return logits
+
+
+class TransformerPolicy(nn.Module):
+    """Policy network based on a Transformer encoder."""
+
+    def __init__(
+        self,
+        input_dim: int,
+        num_heads: int,
+        num_layers: int,
+        output_dim: int,
+    ) -> None:
+        super().__init__()
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=input_dim, nhead=num_heads, batch_first=True
+        )
+        self.encoder = nn.TransformerEncoder(encoder_layer, num_layers=num_layers)
+        self.fc = nn.Linear(input_dim, output_dim)
+
+    def forward(self, state: Tensor, mask: Optional[Tensor] = None) -> Tensor:
+        """Compute masked action logits using a Transformer encoder."""
+        x = self.encoder(state)
+        # Aggregate sequence dimension via mean pooling
+        logits = self.fc(x.mean(dim=1))
+        if mask is not None:
+            logits = logits.masked_fill(~mask, float("-inf"))
+        return logits

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+import torch
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.models.policy import MLPPolicy, TransformerPolicy
+
+
+def _check_mask_application(model, state: torch.Tensor, mask: torch.Tensor) -> None:
+    # Training mode
+    model.train()
+    logits = model(state, mask)
+    assert torch.isinf(logits[~mask]).all()
+
+    # Inference mode
+    model.eval()
+    logits = model(state, mask)
+    assert torch.isinf(logits[~mask]).all()
+
+
+def test_mlp_policy_masking():
+    model = MLPPolicy(input_dim=4, hidden_dim=8, output_dim=3)
+    state = torch.randn(2, 4)
+    mask = torch.tensor([[1, 0, 1], [0, 1, 1]], dtype=torch.bool)
+    _check_mask_application(model, state, mask)
+
+
+def test_transformer_policy_masking():
+    model = TransformerPolicy(input_dim=6, num_heads=2, num_layers=1, output_dim=3)
+    state = torch.randn(2, 5, 6)
+    mask = torch.tensor([[1, 0, 1], [0, 1, 1]], dtype=torch.bool)
+    _check_mask_application(model, state, mask)


### PR DESCRIPTION
## Summary
- implement `MLPPolicy` and `TransformerPolicy` with masking support
- expose policies in `src/models`
- add tests verifying masking during training and inference

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbb69166288325a3d25bba5b648a1e